### PR TITLE
let's use "0.1.x" versioning until we have some confidence in this

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ crossScalaVersions in ThisBuild := Seq("2.13.0-pre-e2a2cba")  // March 16, 2017
 
 scalaVersion in ThisBuild       := crossScalaVersions.value.head
 
-version in ThisBuild            := "1.0.0-SNAPSHOT"
+version in ThisBuild            := "0.1.1-SNAPSHOT"
 
 scalacOptions in ThisBuild      ++= Seq("-deprecation", "-feature")
 
@@ -33,6 +33,6 @@ lazy val scalacheck = project.in(file("scalacheck")).settings(
 ).dependsOn(core)
 
 lazy val testmacros = project.in(file("testmacros")).settings(
-  libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+  libraryDependencies += scalaOrganization.value % "scala-compiler" % scalaVersion.value,
   publishArtifact := false
 )


### PR DESCRIPTION
I've already tagged 0.1.0, so 0.1.1 is next

I also threw in using scalaOrganization.value instead of
hardcoding "org.scala-lang" since that's the new hotness