### PR TITLE
really fix publishing this time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ val disablePublishing = Seq[Setting[_]](
   publishArtifact := false,
   // The above is enough for Maven repos but it doesn't prevent publishing of ivy.xml files
   publish := {},
-  publishLocal := {}
+  publishLocal := {},
+  publishTo := Some(Resolver.file("devnull", file("/dev/null")))
 )
 
 disablePublishing  // in root


### PR DESCRIPTION
sigh, without this we still get

java.lang.RuntimeException: Repository for publishing is not specified.
  at scala.sys.package$.error(package.scala:27)
  at sbt.Classpaths$$anonfun$getPublishTo$1.apply(Defaults.scala:1583)
  at sbt.Classpaths$$anonfun$getPublishTo$1.apply(Defaults.scala:1583)
  at scala.Option.getOrElse(Option.scala:120)
  at sbt.Classpaths$.getPublishTo(Defaults.scala:1583)
  at com.typesafe.sbt.pgp.PgpSettings$$anonfun$signingSettings$2.apply(PgpSettings.scala:125)
  at com.typesafe.sbt.pgp.PgpSettings$$anonfun$signingSettings$2.apply(PgpSettings.scala:124)