### PR TITLE
Updating the logic which locates EC FJP to 2.13

### DIFF
--- a/core/src/main/scala/scala/collection/parallel/Tasks.scala
+++ b/core/src/main/scala/scala/collection/parallel/Tasks.scala
@@ -391,10 +391,12 @@ trait ExecutionContextTasks extends Tasks {
    *  Otherwise, the driver will be a Scala `Future`-based implementation.
    */
   private val driver: Tasks = executionContext match {
-    case eci: scala.concurrent.impl.ExecutionContextImpl => eci.executor match {
-      case fjp: ForkJoinPool => new ForkJoinTaskSupport(fjp)
-      case _ => new FutureTasks(environment)
-    }
+    case fjp: ForkJoinPool => new ForkJoinTaskSupport(fjp)
+    case eci: scala.concurrent.impl.ExecutionContextImpl => 
+      eci.executor match {
+        case fjp: ForkJoinPool => new ForkJoinTaskSupport(fjp)
+        case _ => new FutureTasks(environment)
+      }
     case _ => new FutureTasks(environment)
   }
 


### PR DESCRIPTION
I noticed that there is heuristics for trying to unpack a ForkJoinPool from an ExecutionContext.
This logic has been updated in 2.13-M5 to extend rather than wrap the ForkJoinPool—updating this logic to match.