### PR TITLE
Make the ForkJoinTasks.defaultForkJoinPool delegate to ForkJoin.commonPool()

### DIFF
--- a/core/src/main/scala/scala/collection/parallel/Tasks.scala
+++ b/core/src/main/scala/scala/collection/parallel/Tasks.scala
@@ -289,7 +289,7 @@ trait ForkJoinTasks extends Tasks with HavingForkJoinPool {
 }
 
 object ForkJoinTasks {
-  lazy val defaultForkJoinPool: ForkJoinPool = new ForkJoinPool()
+  lazy val defaultForkJoinPool: ForkJoinPool = ForkJoinPool.commonPool()
 }
 
 /* Some boilerplate due to no deep mixin composition. Not sure if it can be done differently without them.


### PR DESCRIPTION
I guess this is up for discussion—but I think it might make sense to default to the *de facto* default ForkJoinPool?