### PR TITLE
support Scala 2.13 (drop 2.13.0-RC3)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ version in ThisBuild := "0.2.1-SNAPSHOT"
 resolvers in ThisBuild += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
 
 scalaVersionsByJvm in ThisBuild := {
-  val v213 = "2.13.0-RC3"
+  val v213 = "2.13.0"
   Map(
     8 -> List(v213 -> true),
     11 -> List(v213 -> false),


### PR DESCRIPTION
won't be mergeable until ScalaCheck publishes