### PR TITLE
do our JDK 8 testing on OpenJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 script: admin/build.sh
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 cache:

--- a/admin/README.md
+++ b/admin/README.md
@@ -40,8 +40,8 @@ env:
 script: admin/build.sh
 
 jdk:
-  - openjdk6
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 
 notifications:
   email:


### PR DESCRIPTION
we're standardizing on this for modules (and, in general,
across Lightbend)