### PR TITLE
No longer bundle as OSGi

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,32 +10,11 @@ lazy val commonSettings: Seq[Setting[_]] = Seq()
 
 commonSettings  // in root
 
-/** Create an OSGi version range for standard Scala / Lightbend versioning
-  * schemes that describes binary compatible versions. */
-def osgiVersionRange(version: String): String =
-  if(version contains '-') "${@}" // M, RC or SNAPSHOT -> exact version
-  else "${range;[==,=+)}" // Any binary compatible version
-
-/** Create an OSGi Import-Package version specification. */
-def osgiImport(pattern: String, version: String): String =
-  pattern + ";version=\"" + osgiVersionRange(version) + "\""
-
 lazy val core = project.in(file("core"))
   .settings(ScalaModulePlugin.scalaModuleSettings)
-  .settings(ScalaModulePlugin.scalaModuleOsgiSettings)
   .settings(commonSettings)
   .settings(
-  name := "scala-parallel-collections",
-  OsgiKeys.exportPackage := Seq(
-    s"scala.collection.parallel.*;version=${version.value}",
-    // The first entry on the classpath is the project's target classes dir but sbt-osgi also passes all
-    // dependencies to bnd. Any "merge" strategy for split packages would include the classes from scala-library.
-    s"scala.collection;version=${version.value};-split-package:=first",
-    s"scala.collection.generic;version=${version.value};-split-package:=first"
-  ),
-  // Use correct version for scala package imports
-  OsgiKeys.importPackage := Seq(osgiImport("scala*", scalaVersion.value), "*"),
-  scalaModuleMimaPreviousVersion := None
+  name := "scala-parallel-collections"
 )
 
 lazy val junit = project.in(file("junit"))


### PR DESCRIPTION
Fixes https://github.com/scala/scala-parallel-collections/issues/97

Tested by comparing the jars of `package` and `publishLocal`.