### PR TITLE
bump Scala version to 2.13.2 & enable -Werror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ import: scala/scala-dev:travis/default.yml
 language: scala
 
 scala:
-  - 2.13.0
+  - 2.13.2
 
 env:
   - ADOPTOPENJDK=8

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ publish / skip := true // in root
 
 lazy val commonSettings: Seq[Setting[_]] =
   ScalaModulePlugin.scalaModuleSettings ++ Seq(
-    Compile / compile / scalacOptions ++= Seq("-Werror", "-Wconf:cat=deprecation:msg=nested class of a parent:s")
+    Compile / compile / scalacOptions += "-Werror"
   )
 
 lazy val core = project.in(file("core"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,12 @@
-ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature"/*, "-Xfatal-warnings"*/)
-
 Global / cancelable := true
-
 publish / skip := true // in root
 
-lazy val commonSettings: Seq[Setting[_]] = Seq()
-
-commonSettings  // in root
+lazy val commonSettings: Seq[Setting[_]] =
+  ScalaModulePlugin.scalaModuleSettings ++ Seq(
+    Compile / compile / scalacOptions ++= Seq("-Werror", "-Wconf:cat=deprecation:msg=nested class of a parent:s")
+  )
 
 lazy val core = project.in(file("core"))
-  .settings(ScalaModulePlugin.scalaModuleSettings)
   .settings(commonSettings)
   .settings(
     name := "scala-parallel-collections"

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,8 @@
-resolvers in ThisBuild += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
+ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature"/*, "-Xfatal-warnings"*/)
 
-scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature"/*, "-Xfatal-warnings"*/)
+Global / cancelable := true
 
-cancelable in Global := true
-
-skip in publish := true // in root
+publish / skip := true // in root
 
 lazy val commonSettings: Seq[Setting[_]] = Seq()
 
@@ -14,32 +12,32 @@ lazy val core = project.in(file("core"))
   .settings(ScalaModulePlugin.scalaModuleSettings)
   .settings(commonSettings)
   .settings(
-  name := "scala-parallel-collections"
-)
+    name := "scala-parallel-collections"
+  )
 
 lazy val junit = project.in(file("junit"))
   .settings(commonSettings)
   .settings(
-  libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
-  // for javax.xml.bind.DatatypeConverter, used in SerializationStabilityTest
-  libraryDependencies += "javax.xml.bind" % "jaxb-api" % "2.3.1" % Test,
-  testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
-  fork in Test := true,
-  skip in publish := true
-).dependsOn(testmacros, core)
+    libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
+    // for javax.xml.bind.DatatypeConverter, used in SerializationStabilityTest
+    libraryDependencies += "javax.xml.bind" % "jaxb-api" % "2.3.1" % Test,
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
+    Test / fork := true,
+    publish / skip := true
+  ).dependsOn(testmacros, core)
 
 lazy val scalacheck = project.in(file("scalacheck"))
   .settings(commonSettings)
   .settings(
-  libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.3",
-  fork in Test := true,
-  testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-workers", "1", "-minSize", "0", "-maxSize", "4000", "-minSuccessfulTests", "5"),
-  skip in publish := true
-).dependsOn(core)
+    libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.3",
+    Test / fork := true,
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaCheck, "-workers", "1", "-minSize", "0", "-maxSize", "4000", "-minSuccessfulTests", "5"),
+    publish / skip := true
+  ).dependsOn(core)
 
 lazy val testmacros = project.in(file("testmacros"))
   .settings(commonSettings)
   .settings(
-  libraryDependencies += scalaOrganization.value % "scala-compiler" % scalaVersion.value,
-  skip in publish := true
-)
+    libraryDependencies += scalaOrganization.value % "scala-compiler" % scalaVersion.value,
+    publish / skip := true
+  )

--- a/core/src/main/scala/scala/collection/Parallel.scala
+++ b/core/src/main/scala/scala/collection/Parallel.scala
@@ -14,8 +14,5 @@ package scala
 package collection
 
 /** A marker trait for collections which have their operations parallelised.
- *
- *  @since 2.9
- *  @author Aleksandar Prokopec
  */
 trait Parallel

--- a/core/src/main/scala/scala/collection/generic/CanCombineFrom.scala
+++ b/core/src/main/scala/scala/collection/generic/CanCombineFrom.scala
@@ -22,7 +22,6 @@ import scala.collection.parallel._
  *                builder to be created.
  *  @tparam Elem  the element type of the collection to be created.
  *  @tparam To    the type of the collection to be created.
- *  @since 2.8
  */
 trait CanCombineFrom[-From, -Elem, +To] extends Parallel {
   def apply(from: From): Combiner[Elem, To]

--- a/core/src/main/scala/scala/collection/generic/GenericParCompanion.scala
+++ b/core/src/main/scala/scala/collection/generic/GenericParCompanion.scala
@@ -17,7 +17,7 @@ package generic
 import scala.collection.parallel.Combiner
 import scala.collection.parallel.ParIterable
 import scala.collection.parallel.ParMap
-import scala.language.{higherKinds, implicitConversions}
+import scala.language.implicitConversions
 
 /** A template class for companion objects of parallel collection classes.
  *  They should be mixed in together with `GenericCompanion` type.

--- a/core/src/main/scala/scala/collection/generic/GenericParTemplate.scala
+++ b/core/src/main/scala/scala/collection/generic/GenericParTemplate.scala
@@ -24,8 +24,6 @@ import scala.annotation.unchecked.uncheckedVariance
  *
  *  @tparam A    the element type of the collection
  *  @tparam CC   the type constructor representing the collection class
- *  @author Aleksandar Prokopec
- *  @since 2.8
  */
 trait GenericParTemplate[+A, +CC[X] <: ParIterable[X]]
   extends GenericTraversableTemplate[A, CC]

--- a/core/src/main/scala/scala/collection/generic/GenericParTemplate.scala
+++ b/core/src/main/scala/scala/collection/generic/GenericParTemplate.scala
@@ -19,7 +19,6 @@ import scala.collection.parallel.ParIterable
 import scala.collection.parallel.ParMap
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.language.higherKinds
 
 /** A template trait for collections having a companion.
  *

--- a/core/src/main/scala/scala/collection/generic/GenericTraversableTemplate.scala
+++ b/core/src/main/scala/scala/collection/generic/GenericTraversableTemplate.scala
@@ -12,7 +12,6 @@
 
 package scala.collection.generic
 
-import scala.language.higherKinds
 import scala.annotation.migration
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.mutable.Builder

--- a/core/src/main/scala/scala/collection/generic/GenericTraversableTemplate.scala
+++ b/core/src/main/scala/scala/collection/generic/GenericTraversableTemplate.scala
@@ -22,8 +22,6 @@ import scala.collection.parallel.ParIterable
  *
  *  @tparam  A    The type of the collection elements.
  *  @tparam  CC   The type constructor representing the collection class.
- *  @author Martin Odersky
- *  @since 2.8
  *  @define coll  collection
  */
 // TODO inline in GenericParTemplate or ParIterable

--- a/core/src/main/scala/scala/collection/generic/HasNewCombiner.scala
+++ b/core/src/main/scala/scala/collection/generic/HasNewCombiner.scala
@@ -16,9 +16,6 @@ package generic
 
 import scala.collection.parallel.Combiner
 
-/**
- *  @since 2.8
- */
 trait HasNewCombiner[+T, +Repr] {
   protected[this] def newCombiner: Combiner[T, Repr]
 }

--- a/core/src/main/scala/scala/collection/generic/ParFactory.scala
+++ b/core/src/main/scala/scala/collection/generic/ParFactory.scala
@@ -24,7 +24,6 @@ import scala.collection.parallel.ParIterable
  *    This object provides a set of operations needed to create `$Coll` values.
  *  @define coll parallel collection
  *  @define Coll `ParIterable`
- *  @since 2.8
  */
 abstract class ParFactory[CC[X] <: ParIterable[X] with GenericParTemplate[X, CC]]
 extends GenericParCompanion[CC] {

--- a/core/src/main/scala/scala/collection/generic/ParFactory.scala
+++ b/core/src/main/scala/scala/collection/generic/ParFactory.scala
@@ -15,7 +15,6 @@ package collection
 package generic
 
 import scala.collection.parallel.ParIterable
-import scala.language.higherKinds
 
 /** A template class for companion objects of `ParIterable` and subclasses
  *  thereof. This class extends `TraversableFactory` and provides a set of

--- a/core/src/main/scala/scala/collection/generic/ParMapFactory.scala
+++ b/core/src/main/scala/scala/collection/generic/ParMapFactory.scala
@@ -17,7 +17,6 @@ package generic
 import scala.collection.parallel.ParMap
 import scala.collection.parallel.ParMapLike
 import scala.collection.parallel.Combiner
-import scala.language.higherKinds
 
 /** A template class for companion objects of `ParMap` and subclasses thereof.
  *  This class extends `TraversableFactory` and provides a set of operations

--- a/core/src/main/scala/scala/collection/generic/ParMapFactory.scala
+++ b/core/src/main/scala/scala/collection/generic/ParMapFactory.scala
@@ -26,8 +26,6 @@ import scala.collection.parallel.Combiner
  *  @define Coll `ParMap`
  *  @define factoryInfo
  *    This object provides a set of operations needed to create `$Coll` values.
- *  @author Aleksandar Prokopec
- *  @since 2.8
  */
 abstract class ParMapFactory[CC[X, Y] <: ParMap[X, Y] with ParMapLike[X, Y, CC, CC[X, Y], _]]
 extends GenericParMapCompanion[CC] {

--- a/core/src/main/scala/scala/collection/generic/ParSetFactory.scala
+++ b/core/src/main/scala/scala/collection/generic/ParSetFactory.scala
@@ -21,8 +21,6 @@ import scala.collection.parallel.ParSetLike
 /**
  *  @define factoryInfo
  *    This object provides a set of operations needed to create `$Coll` values.
- *  @author Aleksandar Prokopec
- *  @since 2.8
  */
 abstract class ParSetFactory[CC[X] <: ParSet[X] with ParSetLike[X, CC, CC[X], _] with GenericParTemplate[X, CC]]
   extends GenericParCompanion[CC] {

--- a/core/src/main/scala/scala/collection/generic/ParSetFactory.scala
+++ b/core/src/main/scala/scala/collection/generic/ParSetFactory.scala
@@ -17,7 +17,6 @@ package generic
 import scala.collection.parallel.Combiner
 import scala.collection.parallel.ParSet
 import scala.collection.parallel.ParSetLike
-import scala.language.higherKinds
 
 /**
  *  @define factoryInfo

--- a/core/src/main/scala/scala/collection/generic/Signalling.scala
+++ b/core/src/main/scala/scala/collection/generic/Signalling.scala
@@ -25,8 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger
  * signalling interface to inform worker threads that an element has
  * been found and no further search is necessary.
  *
- * @author prokopec
- *
  * @define abortflag
  * Abort flag being true means that a worker can abort and produce whatever result,
  * since its result will not affect the final result of computation. An example

--- a/core/src/main/scala/scala/collection/immutable/OldHashMap.scala
+++ b/core/src/main/scala/scala/collection/immutable/OldHashMap.scala
@@ -28,9 +28,6 @@ import scala.collection.mutable.{Builder, ImmutableBuilder}
   *
   *  @tparam K      the type of the keys contained in this hash map.
   *  @tparam V      the type of the values associated with the keys.
-  *  @author  Martin Odersky
-  *  @author  Tiark Rompf
-  *  @since   2.3
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#hash-tries "Scala's Collection Library overview"]]
   *  section on `Hash Tries` for more information.
   *  @define Coll `immutable.OldHashMap`

--- a/core/src/main/scala/scala/collection/immutable/OldHashSet.scala
+++ b/core/src/main/scala/scala/collection/immutable/OldHashSet.scala
@@ -29,9 +29,6 @@ import scala.annotation.tailrec
   *
   *  @tparam A      the type of the elements contained in this hash set.
   *
-  *  @author  Martin Odersky
-  *  @author  Tiark Rompf
-  *  @since   2.3
   *  @define Coll `immutable.OldHashSet`
   *  @define coll immutable hash set
   */

--- a/core/src/main/scala/scala/collection/mutable/FlatHashTable.scala
+++ b/core/src/main/scala/scala/collection/mutable/FlatHashTable.scala
@@ -26,7 +26,6 @@ import scala.util.hashing.byteswap32
  *  hash table as an implementation.
  *
  *  @define coll flat hash table
- *  @since 2.3
  *  @tparam A   the type of the elements contained in the $coll.
  */
 private[collection] trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {

--- a/core/src/main/scala/scala/collection/parallel/Combiner.scala
+++ b/core/src/main/scala/scala/collection/parallel/Combiner.scala
@@ -29,9 +29,6 @@ import scala.collection.generic.Sizing
  *
  *  @tparam Elem   the type of the elements added to the builder
  *  @tparam To     the type of the collection the builder produces
- *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait Combiner[-Elem, +To] extends Builder[Elem, To] with Sizing with Parallel {
 

--- a/core/src/main/scala/scala/collection/parallel/ParIterable.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParIterable.scala
@@ -23,9 +23,6 @@ import scala.collection.parallel.mutable.ParArrayCombiner
  *  $sideeffects
  *
  *  @tparam T    the element type of the collection
- *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait ParIterable[+T]
   extends GenericParTemplate[T, ParIterable]

--- a/core/src/main/scala/scala/collection/parallel/ParIterableLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParIterableLike.scala
@@ -122,9 +122,6 @@ import scala.reflect.ClassTag
  *  Method `size` is implemented as a constant time operation for parallel collections, and parallel collection
  *  operations rely on this assumption.
  *
- *  @author Aleksandar Prokopec
- *  @since 2.9
- *
  *  @define sideeffects
  *  The higher-order functions passed to certain operations may contain side-effects. Since implementations
  *  of bulk operations may not be sequential, this means that side-effects may not be predictable and may

--- a/core/src/main/scala/scala/collection/parallel/ParIterableLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParIterableLike.scala
@@ -13,7 +13,7 @@
 package scala
 package collection.parallel
 
-import scala.language.{ higherKinds, implicitConversions }
+import scala.language.implicitConversions
 import scala.collection.mutable.Builder
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{CustomParallelizable, IterableOps, Parallel}
@@ -874,7 +874,7 @@ self =>
     protected[this] def newSubtask(p: IterableSplitter[T]): Accessor[R, Tp]
     def shouldSplitFurther = pit.shouldSplitFurther(self.repr, tasksupport.parallelismLevel)
     def split = pit.splitWithSignalling.map(newSubtask(_)) // default split procedure
-    private[parallel] override def signalAbort = pit.abort()
+    private[parallel] override def signalAbort() = pit.abort()
     override def toString = this.getClass.getSimpleName + "(" + pit.toString + ")(" + result + ")(supername: " + super.toString + ")"
   }
 

--- a/core/src/main/scala/scala/collection/parallel/ParMap.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParMap.scala
@@ -25,9 +25,6 @@ import scala.collection.generic.CanCombineFrom
  *
  *  @tparam K    the key type of the map
  *  @tparam V    the value type of the map
- *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait ParMap[K, +V]
 extends GenericParMapTemplate[K, V, ParMap]

--- a/core/src/main/scala/scala/collection/parallel/ParMapLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParMapLike.scala
@@ -28,9 +28,6 @@ import scala.annotation.unchecked.uncheckedVariance
  *  @tparam V    the value type of the map
  *  @define Coll `ParMap`
  *  @define coll parallel map
- *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait ParMapLike[K,
                  +V,

--- a/core/src/main/scala/scala/collection/parallel/ParMapLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParMapLike.scala
@@ -18,7 +18,6 @@ import scala.collection.{IterableOnce, MapOps}
 import scala.collection.Map
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.language.higherKinds
 
 /** A template trait for mutable parallel maps. This trait is to be mixed in
  *  with concrete parallel maps to override the representation type.

--- a/core/src/main/scala/scala/collection/parallel/ParSeq.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParSeq.scala
@@ -26,8 +26,6 @@ import scala.collection.parallel.mutable.ParArrayCombiner
  *  $sideeffects
  *
  *  @tparam T      the type of the elements in this parallel sequence
- *
- *  @author Aleksandar Prokopec
  */
 trait ParSeq[+T] extends ParIterable[T]
                     with GenericParTemplate[T, ParSeq]

--- a/core/src/main/scala/scala/collection/parallel/ParSeqLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParSeqLike.scala
@@ -13,8 +13,6 @@
 package scala
 package collection.parallel
 
-import scala.language.higherKinds
-
 import scala.collection.{AnyConstr, BufferedIterator, Iterator, SeqOps}
 import scala.collection.generic.DefaultSignalling
 import scala.collection.generic.AtomicIndexFlag

--- a/core/src/main/scala/scala/collection/parallel/ParSeqLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParSeqLike.scala
@@ -44,9 +44,6 @@ import scala.collection.parallel.ParallelCollectionImplicits._
  *
  *  This trait defines a new, more general `split` operation and reimplements the `split`
  *  operation of `ParallelIterable` trait using the new `split` operation.
- *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait ParSeqLike[+T, +CC[X] <: ParSeq[X], +Repr <: ParSeq[T], +Sequential <: scala.collection.Seq[T] with SeqOps[T, AnyConstr, Sequential]]
 extends ParIterableLike[T, CC, Repr, Sequential]

--- a/core/src/main/scala/scala/collection/parallel/ParSet.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParSet.scala
@@ -21,9 +21,6 @@ import scala.collection.generic._
  *  $sideeffects
  *
  *  @tparam T    the element type of the set
- *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait ParSet[T]
    extends GenericParTemplate[T, ParSet]

--- a/core/src/main/scala/scala/collection/parallel/ParSetLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParSetLike.scala
@@ -23,9 +23,6 @@ import scala.collection.{Set, SetOps}
  *  @tparam T    the element type of the set
  *  @define Coll `ParSet`
  *  @define coll parallel set
- *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait ParSetLike[T,
                  +CC[X] <: ParIterable[X],

--- a/core/src/main/scala/scala/collection/parallel/ParSetLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParSetLike.scala
@@ -14,7 +14,6 @@ package scala
 package collection.parallel
 
 import scala.collection.{Set, SetOps}
-import scala.language.higherKinds
 
 /** A template trait for parallel sets. This trait is mixed in with concrete
  *  parallel sets to override the representation type.

--- a/core/src/main/scala/scala/collection/parallel/PreciseSplitter.scala
+++ b/core/src/main/scala/scala/collection/parallel/PreciseSplitter.scala
@@ -21,9 +21,6 @@ import scala.collection.Seq
  *  Implementors might want to override the parameterless `split` method for efficiency.
  *
  *  @tparam T     type of the elements this splitter traverses
- *
- *  @since 2.9
- *  @author Aleksandar Prokopec
  */
 trait PreciseSplitter[+T] extends Splitter[T] {
 

--- a/core/src/main/scala/scala/collection/parallel/RemainsIterator.scala
+++ b/core/src/main/scala/scala/collection/parallel/RemainsIterator.scala
@@ -563,24 +563,24 @@ self =>
 
   /* iterator transformers */
 
-  class Taken(tk: Int) extends super.Taken(tk) with SeqSplitter[T] {
+  class RemainsIteratorTaken(tk: Int) extends Taken(tk) with SeqSplitter[T] {
     override def dup = super.dup.asInstanceOf[SeqSplitter[T]]
     override def split: Seq[SeqSplitter[T]] = super.split.asInstanceOf[Seq[SeqSplitter[T]]]
     def psplit(sizes: Int*): Seq[SeqSplitter[T]] = takeSeq(self.psplit(sizes: _*)) { (p, n) => p.take(n) }
   }
-  override private[collection] def newTaken(until: Int): Taken = new Taken(until)
+  override private[collection] def newTaken(until: Int): RemainsIteratorTaken = new RemainsIteratorTaken(until)
   override def take(n: Int): SeqSplitter[T] = newTaken(n)
   override def slice(from1: Int, until1: Int): SeqSplitter[T] = newSliceInternal(newTaken(until1), from1)
 
-  class Mapped[S](f: T => S) extends super.Mapped[S](f) with SeqSplitter[S] {
+  class RemainsIteratorMapped[S](f: T => S) extends Mapped[S](f) with SeqSplitter[S] {
     override def dup = super.dup.asInstanceOf[SeqSplitter[S]]
     override def split: Seq[SeqSplitter[S]] = super.split.asInstanceOf[Seq[SeqSplitter[S]]]
     def psplit(sizes: Int*): Seq[SeqSplitter[S]] = self.psplit(sizes: _*).map { _ map f }
   }
 
-  override def map[S](f: T => S) = new Mapped(f)
+  override def map[S](f: T => S) = new RemainsIteratorMapped(f)
 
-  class Appended[U >: T, PI <: SeqSplitter[U]](it: PI) extends super.Appended[U, PI](it) with SeqSplitter[U] {
+  class RemainsIteratorAppended[U >: T, PI <: SeqSplitter[U]](it: PI) extends Appended[U, PI](it) with SeqSplitter[U] {
     override def dup = super.dup.asInstanceOf[SeqSplitter[U]]
     override def split: Seq[SeqSplitter[U]] = super.split.asInstanceOf[Seq[SeqSplitter[U]]]
     def psplit(sizes: Int*): Seq[SeqSplitter[U]] = if (firstNonEmpty) {
@@ -609,17 +609,17 @@ self =>
     } else curr.asInstanceOf[SeqSplitter[U]].psplit(sizes: _*)
   }
 
-  def appendParSeq[U >: T, PI <: SeqSplitter[U]](that: PI) = new Appended[U, PI](that)
+  def appendParSeq[U >: T, PI <: SeqSplitter[U]](that: PI) = new RemainsIteratorAppended[U, PI](that)
 
-  class Zipped[S](ti: SeqSplitter[S]) extends super.Zipped[S](ti) with SeqSplitter[(T, S)] {
+  class RemainsIteratorZipped[S](ti: SeqSplitter[S]) extends Zipped[S](ti) with SeqSplitter[(T, S)] {
     override def dup = super.dup.asInstanceOf[SeqSplitter[(T, S)]]
     override def split: Seq[SeqSplitter[(T, S)]] = super.split.asInstanceOf[Seq[SeqSplitter[(T, S)]]]
     def psplit(szs: Int*) = (self.psplit(szs: _*) zip that.psplit(szs: _*)) map { p => p._1 zipParSeq p._2 }
   }
 
-  override def zipParSeq[S](that: SeqSplitter[S]) = new Zipped(that)
+  override def zipParSeq[S](that: SeqSplitter[S]) = new RemainsIteratorZipped(that)
 
-  class ZippedAll[U >: T, S](ti: SeqSplitter[S], thise: U, thate: S) extends super.ZippedAll[U, S](ti, thise, thate) with SeqSplitter[(U, S)] {
+  class RemainsIteratorZippedAll[U >: T, S](ti: SeqSplitter[S], thise: U, thate: S) extends ZippedAll[U, S](ti, thise, thate) with SeqSplitter[(U, S)] {
     override def dup = super.dup.asInstanceOf[SeqSplitter[(U, S)]]
     private def patchem = {
       val selfrem = self.remaining
@@ -640,7 +640,7 @@ self =>
     }
   }
 
-  override def zipAllParSeq[S, U >: T, R >: S](that: SeqSplitter[S], thisElem: U, thatElem: R) = new ZippedAll[U, R](that, thisElem, thatElem)
+  override def zipAllParSeq[S, U >: T, R >: S](that: SeqSplitter[S], thisElem: U, thatElem: R) = new RemainsIteratorZippedAll[U, R](that, thisElem, thatElem)
 
   def reverse: SeqSplitter[T] = {
     val pa = mutable.ParArray.fromIterables(self).reverse

--- a/core/src/main/scala/scala/collection/parallel/RemainsIterator.scala
+++ b/core/src/main/scala/scala/collection/parallel/RemainsIterator.scala
@@ -422,7 +422,7 @@ self =>
   class Taken(taken: Int) extends IterableSplitter[T] {
     var remaining = taken min self.remaining
     def hasNext = remaining > 0
-    def next = { remaining -= 1; self.next() }
+    def next() = { remaining -= 1; self.next() }
     def dup: IterableSplitter[T] = self.dup.take(taken)
     def split: Seq[IterableSplitter[T]] = takeSeq(self.split) { (p, n) => p.take(n) }
     protected[this] def takeSeq[PI <: IterableSplitter[T]](sq: Seq[PI])(taker: (PI, Int) => PI) = {
@@ -459,7 +459,7 @@ self =>
   class Mapped[S](f: T => S) extends IterableSplitter[S] {
     signalDelegate = self.signalDelegate
     def hasNext = self.hasNext
-    def next = f(self.next())
+    def next() = f(self.next())
     def remaining = self.remaining
     def dup: IterableSplitter[S] = self.dup map f
     def split: Seq[IterableSplitter[S]] = self.split.map { _ map f }
@@ -474,7 +474,7 @@ self =>
       curr = that
       curr.hasNext
     } else false
-    def next = if (curr eq self) {
+    def next() = if (curr eq self) {
       hasNext
       curr.next()
     } else curr.next()
@@ -489,7 +489,7 @@ self =>
   class Zipped[S](protected val that: SeqSplitter[S]) extends IterableSplitter[(T, S)] {
     signalDelegate = self.signalDelegate
     def hasNext = self.hasNext && that.hasNext
-    def next = (self.next(), that.next())
+    def next() = (self.next(), that.next())
     def remaining = self.remaining min that.remaining
     def dup: IterableSplitter[(T, S)] = self.dup.zipParSeq(that)
     def split: Seq[IterableSplitter[(T, S)]] = {
@@ -506,7 +506,7 @@ self =>
   extends IterableSplitter[(U, S)] {
     signalDelegate = self.signalDelegate
     def hasNext = self.hasNext || that.hasNext
-    def next = if (self.hasNext) {
+    def next() = if (self.hasNext) {
       if (that.hasNext) (self.next(), that.next())
       else (self.next(), thatelem)
     } else (thiselem, that.next())
@@ -656,7 +656,7 @@ self =>
       (pits(0).appendParSeq[U, SeqSplitter[U]](patch)) appendParSeq pits(2)
     }
     def hasNext = trio.hasNext
-    def next = trio.next
+    def next() = trio.next
     def remaining = trio.remaining
     def dup = self.dup.patchParSeq(from, patch, replaced)
     def split = trio.split

--- a/core/src/main/scala/scala/collection/parallel/Splitter.scala
+++ b/core/src/main/scala/scala/collection/parallel/Splitter.scala
@@ -57,7 +57,7 @@ trait Splitter[+T] extends Iterator[T] {
 object Splitter {
   def empty[T]: Splitter[T] = new Splitter[T] {
     def hasNext = false
-    def next = Iterator.empty.next()
+    def next() = Iterator.empty.next()
     def split = Seq(this)
   }
 }

--- a/core/src/main/scala/scala/collection/parallel/Splitter.scala
+++ b/core/src/main/scala/scala/collection/parallel/Splitter.scala
@@ -19,9 +19,6 @@ import scala.collection.{ Seq, Iterator }
  *  disjoint subsets of elements.
  *
  *  @tparam T    type of the elements this splitter traverses
- *
- *  @since 2.9
- *  @author Aleksandar Prokopec
  */
 trait Splitter[+T] extends Iterator[T] {
 

--- a/core/src/main/scala/scala/collection/parallel/Tasks.scala
+++ b/core/src/main/scala/scala/collection/parallel/Tasks.scala
@@ -139,11 +139,11 @@ trait Tasks {
  */
 trait AdaptiveWorkStealingTasks extends Tasks {
 
-  trait WrappedTask[R, Tp] extends super.WrappedTask[R, Tp] {
-    @volatile var next: WrappedTask[R, Tp] = null
+  trait AWSTWrappedTask[R, Tp] extends WrappedTask[R, Tp] {
+    @volatile var next: AWSTWrappedTask[R, Tp] = null
     @volatile var shouldWaitFor = true
 
-    def split: Seq[WrappedTask[R, Tp]]
+    def split: Seq[AWSTWrappedTask[R, Tp]]
 
     def compute() = if (body.shouldSplitFurther) {
       internal()
@@ -178,8 +178,8 @@ trait AdaptiveWorkStealingTasks extends Tasks {
     }
 
     def spawnSubtasks() = {
-      var last: WrappedTask[R, Tp] = null
-      var head: WrappedTask[R, Tp] = this
+      var last: AWSTWrappedTask[R, Tp] = null
+      var head: AWSTWrappedTask[R, Tp] = this
       do {
         val subtasks = head.split
         head = subtasks.head
@@ -237,14 +237,14 @@ trait HavingForkJoinPool {
  */
 trait ForkJoinTasks extends Tasks with HavingForkJoinPool {
 
-  trait WrappedTask[R, +Tp] extends RecursiveAction with super.WrappedTask[R, Tp] {
+  trait FJTWrappedTask[R, +Tp] extends RecursiveAction with WrappedTask[R, Tp] {
     def start() = fork
     def sync() = join
     def tryCancel() = tryUnfork
   }
 
   // specialize ctor
-  protected def newWrappedTask[R, Tp](b: Task[R, Tp]): WrappedTask[R, Tp]
+  protected def newWrappedTask[R, Tp](b: Task[R, Tp]): FJTWrappedTask[R, Tp]
 
   /** The fork/join pool of this collection.
    */
@@ -300,12 +300,12 @@ object ForkJoinTasks {
  */
 trait AdaptiveWorkStealingForkJoinTasks extends ForkJoinTasks with AdaptiveWorkStealingTasks {
 
-  class WrappedTask[R, Tp](val body: Task[R, Tp])
-  extends super[ForkJoinTasks].WrappedTask[R, Tp] with super[AdaptiveWorkStealingTasks].WrappedTask[R, Tp] {
+  class AWSFJTWrappedTask[R, Tp](val body: Task[R, Tp])
+  extends FJTWrappedTask[R, Tp] with AWSTWrappedTask[R, Tp] {
     def split = body.split.map(b => newWrappedTask(b))
   }
 
-  def newWrappedTask[R, Tp](b: Task[R, Tp]) = new WrappedTask[R, Tp](b)
+  def newWrappedTask[R, Tp](b: Task[R, Tp]) = new AWSFJTWrappedTask[R, Tp](b)
 }
 
 /** An implementation of the `Tasks` that uses Scala `Future`s to compute

--- a/core/src/main/scala/scala/collection/parallel/Tasks.scala
+++ b/core/src/main/scala/scala/collection/parallel/Tasks.scala
@@ -240,7 +240,7 @@ trait ForkJoinTasks extends Tasks with HavingForkJoinPool {
   trait WrappedTask[R, +Tp] extends RecursiveAction with super.WrappedTask[R, Tp] {
     def start() = fork
     def sync() = join
-    def tryCancel = tryUnfork
+    def tryCancel() = tryUnfork
   }
 
   // specialize ctor

--- a/core/src/main/scala/scala/collection/parallel/immutable/ParHashMap.scala
+++ b/core/src/main/scala/scala/collection/parallel/immutable/ParHashMap.scala
@@ -33,8 +33,6 @@ import scala.collection.Hashing
  *  @tparam K    the key type of the map
  *  @tparam V    the value type of the map
  *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_hash_tries Scala's Parallel Collections Library overview]]
  *  section on Parallel Hash Tries for more information.
   *

--- a/core/src/main/scala/scala/collection/parallel/immutable/ParHashMap.scala
+++ b/core/src/main/scala/scala/collection/parallel/immutable/ParHashMap.scala
@@ -175,7 +175,7 @@ extends scala.collection.parallel.BucketCombiner[(K, V), ParHashMap[K, V], (K, V
     this
   }
 
-  def result = {
+  def result() = {
     val bucks = buckets.filter(_ != null).map(_.headPtr)
     val root = new Array[OldHashMap[K, V]](bucks.length)
 

--- a/core/src/main/scala/scala/collection/parallel/immutable/ParHashSet.scala
+++ b/core/src/main/scala/scala/collection/parallel/immutable/ParHashSet.scala
@@ -35,8 +35,6 @@ import scala.collection.parallel.Task
  *
  *  @tparam T    the element type of the set
  *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_hash_tries Scala's Parallel Collections Library overview]]
  *  section on Parallel Hash Tries for more information.
  *

--- a/core/src/main/scala/scala/collection/parallel/immutable/ParIterable.scala
+++ b/core/src/main/scala/scala/collection/parallel/immutable/ParIterable.scala
@@ -25,9 +25,6 @@ import scala.collection.parallel.Combiner
  *  $sideeffects
  *
  *  @tparam T    the element type of the collection
- *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait ParIterable[+T]
 extends scala.collection.parallel.ParIterable[T]

--- a/core/src/main/scala/scala/collection/parallel/immutable/ParMap.scala
+++ b/core/src/main/scala/scala/collection/parallel/immutable/ParMap.scala
@@ -27,8 +27,6 @@ import scala.collection.parallel.Combiner
  *  @tparam K    the key type of the map
  *  @tparam V    the value type of the map
  *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait ParMap[K, +V]
 extends GenericParMapTemplate[K, V, ParMap]

--- a/core/src/main/scala/scala/collection/parallel/immutable/ParMap.scala
+++ b/core/src/main/scala/scala/collection/parallel/immutable/ParMap.scala
@@ -20,8 +20,6 @@ import scala.collection.generic.GenericParMapCompanion
 import scala.collection.generic.CanCombineFrom
 import scala.collection.parallel.Combiner
 
-import scala.language.higherKinds
-
 /** A template trait for immutable parallel maps.
  *
  *  $sideeffects

--- a/core/src/main/scala/scala/collection/parallel/immutable/ParRange.scala
+++ b/core/src/main/scala/scala/collection/parallel/immutable/ParRange.scala
@@ -60,7 +60,7 @@ self =>
 
     final def hasNext = ind < len
 
-    final def next = if (hasNext) {
+    final def next() = if (hasNext) {
       val r = range.apply(ind)
       ind += 1
       r

--- a/core/src/main/scala/scala/collection/parallel/immutable/ParRange.scala
+++ b/core/src/main/scala/scala/collection/parallel/immutable/ParRange.scala
@@ -26,8 +26,6 @@ import scala.collection.Iterator
  *
  *  @param range    the sequential range this parallel range was obtained from
  *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_range Scala's Parallel Collections Library overview]]
  *  section on `ParRange` for more information.
  *

--- a/core/src/main/scala/scala/collection/parallel/immutable/ParVector.scala
+++ b/core/src/main/scala/scala/collection/parallel/immutable/ParVector.scala
@@ -121,7 +121,7 @@ private[immutable] class LazyParVectorCombiner[T] extends Combiner[T, ParVector[
     sz = 0
   }
 
-  def result: ParVector[T] = {
+  def result(): ParVector[T] = {
     val rvb = new VectorBuilder[T]
     for (vb <- vectors) {
       rvb ++= vb.result

--- a/core/src/main/scala/scala/collection/parallel/immutable/ParVector.scala
+++ b/core/src/main/scala/scala/collection/parallel/immutable/ParVector.scala
@@ -31,8 +31,6 @@ import immutable.VectorIterator
  *
  *  @tparam T    the element type of the vector
  *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_vector Scala's Parallel Collections Library overview]]
  *  section on `ParVector` for more information.
  *

--- a/core/src/main/scala/scala/collection/parallel/immutable/package.scala
+++ b/core/src/main/scala/scala/collection/parallel/immutable/package.scala
@@ -39,7 +39,7 @@ package immutable {
     class ParIterator(var i: Int = 0, val until: Int = length, elem: T = self.elem) extends SeqSplitter[T] {
       def remaining = until - i
       def hasNext = i < until
-      def next = { i += 1; elem }
+      def next() = { i += 1; elem }
       def dup = new ParIterator(i, until, elem)
       def psplit(sizes: Int*) = {
         val incr = sizes.scanLeft(0)(_ + _)

--- a/core/src/main/scala/scala/collection/parallel/mutable/LazyCombiner.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/LazyCombiner.scala
@@ -31,7 +31,7 @@ trait LazyCombiner[Elem, +To, Buff <: Growable[Elem] with Sizing] extends Combin
   val chain: ArrayBuffer[Buff]
   val lastbuff = chain.last
   def addOne(elem: Elem) = { lastbuff += elem; this }
-  def result: To = allocateAndCopy
+  def result(): To = allocateAndCopy
   def clear() = { chain.clear() }
   def combine[N <: Elem, NewTo >: To](other: Combiner[N, NewTo]): Combiner[N, NewTo] = if (this ne other) {
     if (other.isInstanceOf[LazyCombiner[_, _, _]]) {

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParArray.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParArray.scala
@@ -95,7 +95,7 @@ self =>
   extends SeqSplitter[T] {
     def hasNext = i < until
 
-    def next = {
+    def next() = {
       val elem = arr(i)
       i += 1
       elem.asInstanceOf[T]

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParArray.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParArray.scala
@@ -42,8 +42,6 @@ import scala.reflect.ClassTag
  *
  *  @tparam T        type of the elements in the array
  *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_array Scala's Parallel Collections Library overview]]
  *  section on `ParArray` for more information.
  *

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParArray.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParArray.scala
@@ -590,7 +590,7 @@ self =>
     val targarrseq = ArraySeq.make(targetarr).asInstanceOf[ArraySeq[S]]
 
     // fill it in parallel
-    tasksupport.executeAndWaitResult(new Map[S](f, targetarr, 0, length))
+    tasksupport.executeAndWaitResult(new ParArrayMap[S](f, targetarr, 0, length))
 
     // wrap it into a parallel array
     new ParArray[S](targarrseq)
@@ -652,7 +652,7 @@ self =>
     }
   }
 
-  class Map[S](f: T => S, targetarr: Array[Any], offset: Int, howmany: Int) extends Task[Unit, Map[S]] {
+  class ParArrayMap[S](f: T => S, targetarr: Array[Any], offset: Int, howmany: Int) extends Task[Unit, ParArrayMap[S]] {
     var result = ()
 
     def leaf(prev: Option[Unit]) = {
@@ -667,7 +667,7 @@ self =>
     }
     def split = {
       val fp = howmany / 2
-      List(new Map(f, targetarr, offset, fp), new Map(f, targetarr, offset + fp, howmany - fp))
+      List(new ParArrayMap(f, targetarr, offset, fp), new ParArrayMap(f, targetarr, offset + fp, howmany - fp))
     }
     def shouldSplitFurther = howmany > scala.collection.parallel.thresholdFromSize(length, tasksupport.parallelismLevel)
   }

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParFlatHashTable.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParFlatHashTable.scala
@@ -22,7 +22,6 @@ import scala.collection.parallel.IterableSplitter
  *  @define coll   table
  *  @define Coll   `ParFlatHashTable`
  *
- *  @author Aleksandar Prokopec
  */
 trait ParFlatHashTable[T] extends scala.collection.mutable.FlatHashTable[T] {
 

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParHashMap.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParHashMap.scala
@@ -32,7 +32,6 @@ import scala.collection.parallel.Task
  *  @define Coll `ParHashMap`
  *  @define coll parallel hash map
  *
- *  @author Aleksandar Prokopec
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_hash_tables Scala's Parallel Collections Library overview]]
  *  section on Parallel Hash Tables for more information.
  */

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParHashSet.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParHashSet.scala
@@ -143,7 +143,7 @@ with scala.collection.mutable.FlatHashTable.HashUtils[T] {
     this
   }
 
-  def result: ParHashSet[T] = {
+  def result(): ParHashSet[T] = {
     val contents = if (size >= ParHashSetCombiner.numblocks * sizeMapBucketSize) parPopulate else seqPopulate
     new ParHashSet(contents)
   }

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParHashSet.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParHashSet.scala
@@ -33,7 +33,6 @@ import scala.collection.parallel.Task
  *  @define Coll `ParHashSet`
  *  @define coll parallel hash set
  *
- *  @author Aleksandar Prokopec
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_hash_tables Scala's Parallel Collections Library overview]]
  *  section on Parallel Hash Tables for more information.
  */

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParIterable.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParIterable.scala
@@ -24,9 +24,6 @@ import scala.collection.parallel.{ ParIterableLike, Combiner }
  *  $sideeffects
  *
  *  @tparam T    the element type of the collection
- *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait ParIterable[T] extends scala.collection.parallel.ParIterable[T]
                         with GenericParTemplate[T, ParIterable]

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParMap.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParMap.scala
@@ -23,9 +23,6 @@ import scala.collection.parallel.Combiner
  *
  *  @tparam K    the key type of the map
  *  @tparam V    the value type of the map
- *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait ParMap[K, V]
 extends parallel.ParMap[K, V]

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParMapLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParMapLike.scala
@@ -25,9 +25,6 @@ import scala.collection.mutable.Cloneable
  *  @tparam V    the value type of the map
  *  @define Coll `ParMap`
  *  @define coll parallel map
- *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait ParMapLike[K,
                  V,

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParMapLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParMapLike.scala
@@ -15,7 +15,6 @@ package collection.parallel
 package mutable
 
 import scala.collection.mutable.Cloneable
-import scala.language.higherKinds
 
 /** A template trait for mutable parallel maps. This trait is to be mixed in
  *  with concrete parallel maps to override the representation type.

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParSet.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParSet.scala
@@ -17,8 +17,6 @@ import scala.collection.generic._
 import scala.collection.parallel.Combiner
 
 /** A mutable variant of `ParSet`.
- *
- *  @author Aleksandar Prokopec
  */
 trait ParSet[T]
 extends ParIterable[T]

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParSetLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParSetLike.scala
@@ -15,7 +15,6 @@ package collection
 package parallel.mutable
 
 import scala.collection.mutable.Cloneable
-import scala.language.higherKinds
 import scala.collection.mutable.Growable
 import scala.collection.mutable.Shrinkable
 

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParSetLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParSetLike.scala
@@ -26,9 +26,6 @@ import scala.collection.mutable.Shrinkable
  *  @tparam T    the element type of the set
  *  @define Coll `mutable.ParSet`
  *  @define coll mutable parallel set
- *
- *  @author Aleksandar Prokopec
- *  @since 2.9
  */
 trait ParSetLike[T,
                  +CC[X] <: ParIterable[X],

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParTrieMap.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParTrieMap.scala
@@ -32,8 +32,6 @@ import scala.collection.concurrent.TrieMapIterator
  *  to create the splitter. This means that parallel bulk operations can be
  *  called concurrently with the modifications.
  *
- *  @author Aleksandar Prokopec
- *  @since 2.10
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_concurrent_tries Scala's Parallel Collections Library overview]]
  *  section on `ParTrieMap` for more information.
  */

--- a/core/src/main/scala/scala/collection/parallel/mutable/ParTrieMap.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/ParTrieMap.scala
@@ -58,7 +58,7 @@ extends ParMap[K, V]
 
   override def clear() = ctrie.clear()
 
-  def result = this
+  def result() = this
 
   def get(key: K): Option[V] = ctrie.get(key)
 

--- a/core/src/main/scala/scala/collection/parallel/mutable/UnrolledParArrayCombiner.scala
+++ b/core/src/main/scala/scala/collection/parallel/mutable/UnrolledParArrayCombiner.scala
@@ -31,7 +31,7 @@ extends Combiner[T, ParArray[T]] {
     this
   }
 
-  def result = {
+  def result() = {
     val array = new Array[Any](size)
     val arrayseq = ArraySeq.make(array).asInstanceOf[ArraySeq[T]]
 

--- a/core/src/main/scala/scala/collection/parallel/package.scala
+++ b/core/src/main/scala/scala/collection/parallel/package.scala
@@ -113,7 +113,7 @@ package parallel {
   extends IterableSplitter[T] {
     signalDelegate = _sigdel
     def hasNext = index < until
-    def next = {
+    def next() = {
       val r = buffer(index)
       index += 1
       r

--- a/testmacros/src/main/scala/testutil/ShouldNotTypecheck.scala
+++ b/testmacros/src/main/scala/testutil/ShouldNotTypecheck.scala
@@ -15,7 +15,6 @@ package testutil
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 import scala.reflect.macros.TypecheckException
-import scala.util.control.NonFatal
 import java.util.regex.Pattern
 
 /**


### PR DESCRIPTION
I guess the steward didn't update the Scala version because it only appears in `.travis.yml`, because sbt-scala-module brings in sbt-travisci

one of the commits fixes #93 

with sbt-scala-module, you have to be careful to customize `scalacOptions` the same way the plugin does (via the `Compile / compile` scope). discovered in the process we'd been doing it wrong in this repo