### PR TITLE
Some operators against empty collection should throw UnsupportedOperationException

### DIFF
--- a/core/src/main/scala/scala/collection/parallel/ParIterableLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParIterableLike.scala
@@ -465,6 +465,8 @@ extends IterableOnce[T @uncheckedVariance]
   }
 
   def min[U >: T](implicit ord: Ordering[U]): T = {
+    if (isEmpty) throw new UnsupportedOperationException("empty.min")
+
     tasksupport.executeAndWaitResult(new Min(ord, splitter)).get.asInstanceOf[T]
   }
 

--- a/core/src/main/scala/scala/collection/parallel/ParIterableLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParIterableLike.scala
@@ -471,6 +471,8 @@ extends IterableOnce[T @uncheckedVariance]
   }
 
   def max[U >: T](implicit ord: Ordering[U]): T = {
+    if (isEmpty) throw new UnsupportedOperationException("empty.max")
+
     tasksupport.executeAndWaitResult(new Max(ord, splitter)).get.asInstanceOf[T]
   }
 

--- a/core/src/main/scala/scala/collection/parallel/ParIterableLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParIterableLike.scala
@@ -358,6 +358,8 @@ extends IterableOnce[T @uncheckedVariance]
    *  if this $coll is empty.
    */
   def reduce[U >: T](op: (U, U) => U): U = {
+    if (isEmpty) throw new UnsupportedOperationException("empty.reduce")
+
     tasksupport.executeAndWaitResult(new Reduce(op, splitter)).get
   }
 

--- a/junit/src/test/scala/scala/collection/parallel/mutable/ParArrayTest.scala
+++ b/junit/src/test/scala/scala/collection/parallel/mutable/ParArrayTest.scala
@@ -138,4 +138,9 @@ class ParArrayTest extends scala.collection.concurrent.ctries_old.Spec {
     evaluating { ParArray.empty[Int].min }.shouldProduce[UnsupportedOperationException]()
   }
 
+  @Test
+  def `empty max`: Unit = {
+    evaluating { ParArray.empty[Int].max }.shouldProduce[UnsupportedOperationException]()
+  }
+
 }

--- a/junit/src/test/scala/scala/collection/parallel/mutable/ParArrayTest.scala
+++ b/junit/src/test/scala/scala/collection/parallel/mutable/ParArrayTest.scala
@@ -132,4 +132,10 @@ class ParArrayTest extends scala.collection.concurrent.ctries_old.Spec {
   def `simple map test`: Unit = {
     assert(ParArray(1,2,3,4,5).map( (_:Int) * 10 ) == ParArray(10,20,30,40,50))
   }
+
+  @Test
+  def `empty min`: Unit = {
+    evaluating { ParArray.empty[Int].min }.shouldProduce[UnsupportedOperationException]()
+  }
+
 }

--- a/junit/src/test/scala/scala/collection/parallel/mutable/ParArrayTest.scala
+++ b/junit/src/test/scala/scala/collection/parallel/mutable/ParArrayTest.scala
@@ -143,4 +143,9 @@ class ParArrayTest extends scala.collection.concurrent.ctries_old.Spec {
     evaluating { ParArray.empty[Int].max }.shouldProduce[UnsupportedOperationException]()
   }
 
+  @Test
+  def `empty minBy`: Unit = {
+    evaluating { ParArray.empty[String].minBy(_.length) }.shouldProduce[UnsupportedOperationException]()
+  }
+
 }

--- a/junit/src/test/scala/scala/collection/parallel/mutable/ParArrayTest.scala
+++ b/junit/src/test/scala/scala/collection/parallel/mutable/ParArrayTest.scala
@@ -86,6 +86,11 @@ class ParArrayTest extends scala.collection.concurrent.ctries_old.Spec {
   }
 
   @Test
+  def `empty reduce`: Unit = {
+    evaluating { ParArray.empty[Int].reduce(_+_) }.shouldProduce[UnsupportedOperationException]()
+  }
+
+  @Test
   def `simple count`: Unit = {
     assert( ParArray[Int]().count(_ > 7) == 0 )
     assert( ParArray(1,2,3).count(_ > 7) == 0 )

--- a/junit/src/test/scala/scala/collection/parallel/mutable/ParArrayTest.scala
+++ b/junit/src/test/scala/scala/collection/parallel/mutable/ParArrayTest.scala
@@ -148,4 +148,9 @@ class ParArrayTest extends scala.collection.concurrent.ctries_old.Spec {
     evaluating { ParArray.empty[String].minBy(_.length) }.shouldProduce[UnsupportedOperationException]()
   }
 
+  @Test
+  def `emtpy maxBy`: Unit = {
+    evaluating { ParArray.empty[String].maxBy(_.length) }.shouldProduce[UnsupportedOperationException]()
+  }
+
 }


### PR DESCRIPTION
Closes the issue https://github.com/scala/scala-parallel-collections/issues/137 😄 

Operators below against empty collection should throw `UnsupportedOperationException`.
- `reduce`
- `min`
- `max`
- `minBy`
- `maxBy`

We can see `scala.collection.iterator.reduce` throws `UnsupportedOperationException` if the collection is empty.
[scala.collection.iterator#reduce](https://www.scala-lang.org/api/current/scala/collection/Iterator.html#reduce[B%3E:A](op:(B,B)=%3EB):B)

## Changes
- `Nil.par.reduce` throws `UnsupportedOperationException`.
- `Nil.par.min` throws `UnsupportedOperationException`.
- `Nil.par.max` throws `UnsupportedOperationException`.
- Add a test whether `Nil.par.minBy` throws `UnsupportedOperationException`.
- Add a test whether `Nil.par.maxBy` throws `UnsupportedOperationException`.