### PR TITLE
Include links to Scala standard library types in generated Scaladoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ lazy val core = project.in(file("core"))
     // don't run Dottydoc, it errors and isn't needed anyway.
     // but we leave `publishArtifact` set to true, otherwise Sonatype won't let us publish
     Compile / doc / sources := (if (isDotty.value) Seq() else (Compile / doc/ sources).value),
+    Compile / doc / autoAPIMappings := true,
     scalaModuleMimaPreviousVersion := Some("1.0.0").filterNot(_ => isDotty.value),
   )
 


### PR DESCRIPTION
Closes https://github.com/scala/scala-parallel-collections/issues/73

*sbt* provides the `autoAPIMappings` option.

> https://www.scala-sbt.org/1.x/docs/Howto-Scaladoc.html#Enable+automatic+linking+to+the+external+Scaladoc+of+managed+dependencies
> 
> Set autoAPIMappings := true for sbt to tell scaladoc where it can find the API documentation for managed dependencies. This requires that dependencies have this information in its metadata and you are using scaladoc for Scala 2.10.2 or later.

Before
![before_edited](https://user-images.githubusercontent.com/5388508/112496297-f8f8df00-8dc7-11eb-884f-0210cbd93f33.jpg)

After
![after_edited](https://user-images.githubusercontent.com/5388508/112496309-fbf3cf80-8dc7-11eb-9f83-3c91a58647a0.jpg)
