### PR TITLE
add JDK 17 to CI (and some version bumps)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,12 @@ language: scala
 
 scala:
   - 3.0.0
-  - 3.0.0-RC3
-  - 2.13.5
+  - 2.13.6
 
 env:
   - ADOPTOPENJDK=8
   - ADOPTOPENJDK=11
-  - ADOPTOPENJDK=16
+  - ADOPTOPENJDK=17
 
 install:
   - git fetch --tags # get all tags for sbt-dynver


### PR DESCRIPTION
empty `.jvmopts` is to work around dwijnand/sbt-extras#326