### PR TITLE
relax compatibility, fixing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,12 @@ jobs:
         java: [8]
         scala: [3.next]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'schedule' }}
+    if: "github.event_name == 'schedule' && github.repository == 'scala/scala-parallel-collections'
+         || github.event_name == 'push'
+         || (
+           github.event_name == 'pull_request'
+           && contains(github.event.pull_request.body, '[test-rc]')
+         )"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ publish / skip := true // in root
 lazy val commonSettings: Seq[Setting[_]] =
   Seq(scalaModuleAutomaticModuleName := Some("scala.collection.parallel")) ++
   ScalaModulePlugin.scalaModuleSettings ++ Seq(
-    versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+    versionPolicyIntention := Compatibility.BinaryCompatible,
     Compile / compile / scalacOptions --= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((3, _)) => Seq("-Xlint")
       case _            => Seq()


### PR DESCRIPTION
without this change, `versionPolicyCheck` fails on 3.1, but just checking backwards-compat, not forwards, is fine here as far as Dale and I can see

sample failing run: https://github.com/scala/scala-parallel-collections/runs/4245867922

[test-rc]