### PR TITLE
prepare for Scala 2.13.9 upgrade

### DIFF
--- a/core/src/main/scala/scala/collection/immutable/TrieIterator.scala
+++ b/core/src/main/scala/scala/collection/immutable/TrieIterator.scala
@@ -39,7 +39,7 @@ private[collection] abstract class TrieIterator[+T](elems: Array[Iterable[T]]) e
   def initSubIter: Iterator[T]                      = null // to traverse collision nodes
 
   private[this] var depth                                     = initDepth
-  private[this] var arrayStack: Array[Array[Iterable[T @uV]]] = initArrayStack
+  private[this] val arrayStack: Array[Array[Iterable[T @uV]]] = initArrayStack
   private[this] var posStack                                  = initPosStack
   private[this] var arrayD: Array[Iterable[T @uV]]            = initArrayD
   private[this] var posD                                      = initPosD

--- a/core/src/main/scala/scala/collection/parallel/ParSeqLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParSeqLike.scala
@@ -62,8 +62,8 @@ extends ParIterableLike[T, CC, Repr, Sequential]
     *            this sequence in the same order, `false` otherwise
     */
   override def equals(that: Any): Boolean = that match {
-    case that: ParSeq[_] => (that eq this.asInstanceOf[AnyRef]) || (that canEqual this) && (this sameElements that)
-    case _               => false
+    case that: ParSeq[Any] => (that eq this.asInstanceOf[AnyRef]) || (that canEqual this) && (this sameElements that)
+    case _                 => false
   }
 
   def canEqual(other: Any): Boolean = true


### PR DESCRIPTION
the warnings this eliminates are new with `++2.13.9-bin-e623b15`