### PR TITLE
sbt 1.7.0 (was 1.6.2); build cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [8, 11, 17]
-        scala: [2.13.8, 3.1.3]
+        scala: [2.13.x, 3.x]
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'schedule' }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,6 @@
 ThisBuild / crossScalaVersions := Seq("2.13.8", "3.1.3")
 ThisBuild / scalaVersion := (ThisBuild / crossScalaVersions).value.head
 
-// shouldn't be necessary anymore after https://github.com/lampepfl/dotty/pull/13498
-// makes it into a release
-ThisBuild / libraryDependencySchemes += "org.scala-lang" %% "scala3-library" % "semver-spec"
-
-// this was necessary to get us from 3.0.0 to 3.0.2, but we should be able to remove
-// it after the next release
-import com.typesafe.tools.mima.core._
-ThisBuild / mimaBinaryIssueFilters ++= Seq(
-  ProblemFilters.exclude[IncompatibleSignatureProblem]("*"),
-)
-
 Global / cancelable := true
 publish / skip := true // in root
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.0


### PR DESCRIPTION
not waiting for the steward, because I want to use the new 1.7 feature to clean up the Actions config a bit