### PR TITLE
fix sbt 1.7 upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,10 +56,10 @@ lazy val testmacros = project.in(file("testmacros"))
     publish / skip := true,
   )
 
-commands += Command.single("setScalaVersion") { (state, arg0) =>
-  val arg = arg0 match {
-    case "3.next" => GetScala3Next.get()
-    case _        => arg0
+commands += Command.single("setScalaVersion") { (state, arg) =>
+  val command = arg match {
+    case "3.next" => s"++${GetScala3Next.get()}!"
+    case _        => s"++$arg"
   }
-  s"++$arg" :: state
+  command :: state
 }


### PR DESCRIPTION
this wasn't caught by PR validation because the "Scala 3.next" job only runs as a cron

fixes the failure seen at e.g. https://github.com/scala/scala-parallel-collections/runs/7291278922