### PR TITLE
fix: update parent type of `ParSeqLike`

### DIFF
--- a/core/src/main/scala/scala/collection/parallel/ParSeqLike.scala
+++ b/core/src/main/scala/scala/collection/parallel/ParSeqLike.scala
@@ -13,7 +13,7 @@
 package scala
 package collection.parallel
 
-import scala.collection.{AnyConstr, BufferedIterator, Iterator, SeqOps}
+import scala.collection.{BufferedIterator, Iterator, SeqOps}
 import scala.collection.generic.DefaultSignalling
 import scala.collection.generic.AtomicIndexFlag
 import scala.collection.generic.VolatileAbort
@@ -46,7 +46,7 @@ import scala.annotation.unchecked.uncheckedVariance
  *  This trait defines a new, more general `split` operation and reimplements the `split`
  *  operation of `ParallelIterable` trait using the new `split` operation.
  */
-trait ParSeqLike[+T, +CC[X] <: ParSeq[X], +Repr <: ParSeq[T], +Sequential <: scala.collection.Seq[T] with SeqOps[T, AnyConstr, Sequential]]
+trait ParSeqLike[+T, +CC[X] <: ParSeq[X], +Repr <: ParSeq[T], +Sequential <: scala.collection.Seq[T] with SeqOps[T, collection.Seq, Sequential]]
 extends ParIterableLike[T, CC, Repr, Sequential]
    with Equals { self =>
 


### PR DESCRIPTION
Starting from Scala 3.8.0, the following code will not compile due to removing some unsound typing rules. See https://github.com/scala/scala3/pull/23441 for more details.